### PR TITLE
Use linked lists and Map instead of Record and Array. 

### DIFF
--- a/src/components/ECCCalculator.test.tsx
+++ b/src/components/ECCCalculator.test.tsx
@@ -347,7 +347,8 @@ describe('ECCCalculator', () => {
       // Verify that all intermediate points from the algorithm exist in the graph
       for (const intermediate of intermediates) {
         const foundNode = graphNodes.find(
-          (node: GraphNode) => node.point.x === intermediate.point.x && node.point.y === intermediate.point.y
+          (node: GraphNode) =>
+            node.point.x === intermediate.point.x && node.point.y === intermediate.point.y
         );
         expect(foundNode).toBeDefined();
       }
@@ -405,7 +406,9 @@ describe('ECCCalculator', () => {
       const generatorNode = graphNodes.find(
         (node: GraphNode) => node.point.x === generatorPoint.x && node.point.y === generatorPoint.y
       );
-      const twoGNode = graphNodes.find((node: GraphNode) => node.point.x === twoG.x && node.point.y === twoG.y);
+      const twoGNode = graphNodes.find(
+        (node: GraphNode) => node.point.x === twoG.x && node.point.y === twoG.y
+      );
 
       expect(generatorNode).toBeDefined();
       expect(twoGNode).toBeDefined();
@@ -444,7 +447,9 @@ describe('ECCCalculator', () => {
       const generatorNode = graphNodes.find(
         (node: GraphNode) => node.point.x === generatorPoint.x && node.point.y === generatorPoint.y
       );
-      const twoGNode = graphNodes.find((node: GraphNode) => node.point.x === twoG.x && node.point.y === twoG.y);
+      const twoGNode = graphNodes.find(
+        (node: GraphNode) => node.point.x === twoG.x && node.point.y === twoG.y
+      );
 
       expect(generatorNode).toBeDefined();
       expect(twoGNode).toBeDefined();
@@ -482,16 +487,25 @@ describe('ECCCalculator', () => {
       });
 
       const graph = getCachedGraph('daily');
-      
+
       // Flatten all edges from the graph
-      const allEdges = Object.values(graph.edges).flat();
+      const allEdges: GraphEdge[] = [];
+      Object.values(graph.edges).forEach(edgeHead => {
+        let current = edgeHead;
+        while (current !== null) {
+          allEdges.push(current.val);
+          current = current.next;
+        }
+      });
 
       // Should have edges connecting intermediate points
       expect(allEdges.length).toBeGreaterThan(1);
 
       // All intermediate edges should be marked as system-generated
-      const systemEdges = allEdges.filter((edge: GraphEdge) => edge.operation.userCreated === false);
-      
+      const systemEdges = allEdges.filter(
+        (edge: GraphEdge) => edge.operation.userCreated === false
+      );
+
       expect(systemEdges.length).toBeGreaterThan(0);
     });
   });

--- a/src/components/ECCCalculator.test.tsx
+++ b/src/components/ECCCalculator.test.tsx
@@ -338,7 +338,7 @@ describe('ECCCalculator', () => {
 
       // The graph should contain the intermediate points
       const graph = getCachedGraph('daily');
-      const graphNodes = Object.values(graph.nodes);
+      const graphNodes = Array.from(graph.nodes.values());
 
       // Should have at least: generator + final result + intermediates + negated points
       // Each operation adds its result point + negated point, plus intermediates
@@ -396,7 +396,7 @@ describe('ECCCalculator', () => {
       });
 
       const graph = getCachedGraph('daily');
-      const graphNodes = Object.values(graph.nodes);
+      const graphNodes = Array.from(graph.nodes.values());
 
       // Should have multiple nodes from both operations and their intermediates
       expect(graphNodes.length).toBeGreaterThan(2);
@@ -436,7 +436,7 @@ describe('ECCCalculator', () => {
       });
 
       const graph = getCachedGraph('daily');
-      const graphNodes = Object.values(graph.nodes);
+      const graphNodes = Array.from(graph.nodes.values());
 
       // Quick operations may still generate some nodes, but should be reasonable
       // The exact count may vary based on implementation
@@ -490,7 +490,7 @@ describe('ECCCalculator', () => {
 
       // Flatten all edges from the graph
       const allEdges: GraphEdge[] = [];
-      Object.values(graph.edges).forEach(edgeHead => {
+      Array.from(graph.edges.values()).forEach(edgeHead => {
         let current = edgeHead;
         while (current !== null) {
           allEdges.push(current.val);

--- a/src/components/ECCGraph.css
+++ b/src/components/ECCGraph.css
@@ -166,6 +166,7 @@
   border-radius: 8px;
   overflow: hidden;
   margin-bottom: 1rem;
+  touch-action: pinch-zoom;
 }
 
 .graph-border {
@@ -388,6 +389,7 @@
   height: min(80vh, 80vw);
   aspect-ratio: 1;
   flex-shrink: 0;
+  touch-action: pinch-zoom;
 }
 
 /* Mobile responsive */

--- a/src/components/ECCPlayground.tsx
+++ b/src/components/ECCPlayground.tsx
@@ -251,6 +251,9 @@ const ECCPlayground: React.FC<ECCPlaygroundProps> = ({
         practicePrivateKey={practicePrivateKey}
         point={modalPoint}
         onLoadPoint={loadPoint}
+        isCurrentPoint={
+          modalPoint ? modalPoint.x === currentPoint.x && modalPoint.y === currentPoint.y : false
+        }
         onCopyPrivateKeyToCalculator={(privateKey: string) => {
           if (calculatorDisplayRef.current) {
             calculatorDisplayRef.current(privateKey);

--- a/src/components/ECCPlayground.tsx
+++ b/src/components/ECCPlayground.tsx
@@ -9,6 +9,7 @@ import {
   calculateChallengePrivateKeyFromGraph,
   findNodeByPoint,
   calculatePrivateKeyFromGraph,
+  reverseOperation,
 } from '../utils/graphOperations';
 import ECCCalculator from './ECCCalculator';
 import ECCGraph from './ECCGraph';
@@ -112,12 +113,13 @@ const ECCPlayground: React.FC<ECCPlaygroundProps> = ({
           seenEdgeIds.add(edge.id);
 
           // Also add the reverse edge ID to avoid counting the reverse direction
-          const reverseEdgeId = `${edge.toNodeId}_to_${edge.fromNodeId}_by_operation_${edge.operation.type}_${edge.operation.value}`;
+          const reversedOp = reverseOperation(edge.operation);
+          const reverseEdgeId = `${edge.toNodeId}_to_${edge.fromNodeId}_by_operation_${reversedOp.type}_${reversedOp.value}`;
           seenEdgeIds.add(reverseEdgeId);
         }
       }
     }
-    setTotalOperationCount(total / 2);
+    setTotalOperationCount(total);
   }, [graph, hasWon]);
 
   // Note: Removed automatic reset to generator when challenge changes

--- a/src/components/PointModal.tsx
+++ b/src/components/PointModal.tsx
@@ -30,6 +30,8 @@ interface ModalProps {
   onLoadPoint?: (point: ECPoint) => void;
   // Calculator integration
   onCopyPrivateKeyToCalculator?: (privateKey: string) => void;
+  // UI state
+  isCurrentPoint?: boolean;
 }
 
 interface ModalItemProps {
@@ -51,6 +53,7 @@ export const Modal: React.FC<ModalProps> = ({
   point,
   onLoadPoint,
   onCopyPrivateKeyToCalculator,
+  isCurrentPoint = false,
 }) => {
   const dispatch = useAppDispatch();
   const privateKeyDisplayMode = useAppSelector(state => state.ui.privateKeyDisplayMode);
@@ -331,8 +334,8 @@ export const Modal: React.FC<ModalProps> = ({
 
             {/* Action Buttons */}
             <div className="modal-actions">
-              {/* Use as Current Point button for all points */}
-              {onLoadPoint && point && (
+              {/* Use as Current Point button for all points - hide for current point */}
+              {onLoadPoint && point && !isCurrentPoint && (
                 <button
                   className="action-button primary"
                   onClick={() => {

--- a/src/components/SavePointModal.css
+++ b/src/components/SavePointModal.css
@@ -91,7 +91,6 @@
     min-width: auto;
     width: 95vw;
     max-width: 95vw;
-    padding: var(--spacing);
   }
 
   .form-field input {

--- a/src/hooks/useDailyCalculatorRedux.ts
+++ b/src/hooks/useDailyCalculatorRedux.ts
@@ -59,6 +59,7 @@ export function useDailyCalculatorRedux(challengePublicKey: string) {
     showVictoryModal: dailyState.showVictoryModal,
     savedPoints: dailyState.savedPoints,
     shouldSubmitSolution: dailyState.shouldSubmitSolution,
+    userOperationCount: dailyState.userOperationCount,
     // Actions
     setCurrentPoint: (point: ECPoint) => dispatch(setSelectedPoint(point)),
     setError: (error: string | null) => dispatch(setError(error)),

--- a/src/hooks/usePracticeCalculatorRedux.ts
+++ b/src/hooks/usePracticeCalculatorRedux.ts
@@ -85,6 +85,7 @@ export function usePracticeCalculatorRedux(challengePublicKey: string, practiceP
     hasWon: practiceState.hasWon,
     showVictoryModal: practiceState.showVictoryModal,
     savedPoints: practiceState.savedPoints,
+    userOperationCount: practiceState.userOperationCount,
     // Actions
     setCurrentPoint: (point: ECPoint) => dispatch(setSelectedPoint(point)),
     setError: (error: string | null) => dispatch(setError(error)),

--- a/src/index.css
+++ b/src/index.css
@@ -139,7 +139,7 @@ body {
   background: var(--surface);
   color: var(--text);
   -webkit-tap-highlight-color: transparent;
-  touch-action: manipulation;
+  touch-action: pan-y pan-x;
   min-width: 320px;
 }
 

--- a/src/store/slices/eccCalculatorSlice.test.ts
+++ b/src/store/slices/eccCalculatorSlice.test.ts
@@ -64,7 +64,14 @@ describe('DailyCalculatorSlice Force Multiplication', () => {
       // (negatedNode variable removed to fix linter error)
 
       // Should have edges: G -> 3G (multiply) and potentially other edges
-      const edges = Object.values(graph.edges).flat() as GraphEdge[];
+      const edges: GraphEdge[] = [];
+      Object.values(graph.edges).forEach(edgeHead => {
+        let current = edgeHead;
+        while (current !== null) {
+          edges.push(current.val);
+          current = current.next;
+        }
+      });
       expect(edges).toHaveLength(2); // May have additional edges due to implementation
 
       const multiplyEdge = edges.find(edge => edge.operation.type === 'multiply');
@@ -182,7 +189,14 @@ describe('DailyCalculatorSlice Force Multiplication', () => {
       // Use cached graph instead of state.graph
       const graph = getCachedGraph('daily');
       const nodes = Object.values(graph.nodes) as GraphNode[];
-      const edges = Object.values(graph.edges).flat() as GraphEdge[];
+      const edges: GraphEdge[] = [];
+      Object.values(graph.edges).forEach(edgeHead => {
+        let current = edgeHead;
+        while (current !== null) {
+          edges.push(current.val);
+          current = current.next;
+        }
+      });
 
       // Should have G + 3 points (automatic negation may not be working as expected)
       expect(nodes).toHaveLength(4);

--- a/src/store/slices/eccCalculatorSlice.test.ts
+++ b/src/store/slices/eccCalculatorSlice.test.ts
@@ -57,7 +57,7 @@ describe('DailyCalculatorSlice Force Multiplication', () => {
       const graph = getCachedGraph('daily');
 
       // Should have nodes for fromPoint, toPoint, and negated toPoint
-      const nodes = Object.values(graph.nodes) as GraphNode[];
+      const nodes = Array.from(graph.nodes.values()) as GraphNode[];
       expect(nodes).toHaveLength(2); // G, 3G (automatic negation may not be working as expected)
 
       // Check that negated point exists
@@ -65,7 +65,7 @@ describe('DailyCalculatorSlice Force Multiplication', () => {
 
       // Should have edges: G -> 3G (multiply) and potentially other edges
       const edges: GraphEdge[] = [];
-      Object.values(graph.edges).forEach(edgeHead => {
+      Array.from(graph.edges.values()).forEach(edgeHead => {
         let current = edgeHead;
         while (current !== null) {
           edges.push(current.val);
@@ -109,7 +109,7 @@ describe('DailyCalculatorSlice Force Multiplication', () => {
 
       // Use cached graph instead of state.graph
       const graph = getCachedGraph('daily');
-      const nodes = Object.values(graph.nodes) as GraphNode[];
+      const nodes = Array.from(graph.nodes.values()) as GraphNode[];
 
       // Should have: G, challenge, result (automatic negation may not be working as expected)
       expect(nodes).toHaveLength(3);
@@ -153,7 +153,7 @@ describe('DailyCalculatorSlice Force Multiplication', () => {
 
       // Use cached graph instead of state.graph
       const graph = getCachedGraph('daily');
-      const nodes = Object.values(graph.nodes) as GraphNode[];
+      const nodes = Array.from(graph.nodes.values()) as GraphNode[];
 
       // Should have: G, 5G, 3G (automatic negation may not be working as expected)
       expect(nodes.length).toBeGreaterThanOrEqual(3);
@@ -188,9 +188,9 @@ describe('DailyCalculatorSlice Force Multiplication', () => {
 
       // Use cached graph instead of state.graph
       const graph = getCachedGraph('daily');
-      const nodes = Object.values(graph.nodes) as GraphNode[];
+      const nodes = Array.from(graph.nodes.values()) as GraphNode[];
       const edges: GraphEdge[] = [];
-      Object.values(graph.edges).forEach(edgeHead => {
+      Array.from(graph.edges.values()).forEach(edgeHead => {
         let current = edgeHead;
         while (current !== null) {
           edges.push(current.val);
@@ -243,7 +243,7 @@ describe('DailyCalculatorSlice Force Multiplication', () => {
 
       // Use cached graph instead of state.graph
       const graph = getCachedGraph('daily');
-      const nodes = Object.values(graph.nodes) as GraphNode[];
+      const nodes = Array.from(graph.nodes.values()) as GraphNode[];
 
       // Should have: G, 2G (automatic negation may not be working as expected)
       expect(nodes.length).toBeGreaterThanOrEqual(2);

--- a/src/store/slices/eccCalculatorSlice.ts
+++ b/src/store/slices/eccCalculatorSlice.ts
@@ -281,7 +281,7 @@ const dailyCalculatorSlice = createSlice({
       // Win condition: challenge node is connected to generator (has connectedToG property)
       if (state.challengeNodeId && state.generatorNodeId) {
         const graph = getCachedGraph('daily');
-        const challengeNode = graph.nodes[state.challengeNodeId];
+        const challengeNode = graph.nodes.get(state.challengeNodeId);
         if (challengeNode?.connectedToG && !state.hasWon) {
           state.hasWon = true;
           state.showVictoryModal = true;

--- a/src/store/slices/gameSlice.test.ts
+++ b/src/store/slices/gameSlice.test.ts
@@ -29,7 +29,7 @@ describe('State Persistence with switchGameMode', () => {
     );
 
     // Get the practice mode state
-    const practiceNodeCount = Object.keys(getCachedGraph('practice').nodes).length;
+    const practiceNodeCount = getCachedGraph('practice').nodes.size;
     const practiceGeneratorId = (store.getState() as RootState).practiceCalculator.generatorNodeId;
     const practiceChallengeId = (store.getState() as RootState).practiceCalculator.challengeNodeId;
 
@@ -45,16 +45,20 @@ describe('State Persistence with switchGameMode', () => {
       resetToChallenge('03678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb6')
     );
 
-    const dailyNodeCount = Object.keys(getCachedGraph('daily').nodes).length;
+    const dailyNodeCount = getCachedGraph('daily').nodes.size;
     expect(dailyNodeCount).toBeGreaterThan(1);
 
     // Switch back to practice mode - state should be restored
     store.dispatch(switchGameMode('practice'));
 
-    const restoredPracticeNodeCount = Object.keys(getCachedGraph('practice').nodes).length;
+    const restoredPracticeNodeCount = getCachedGraph('practice').nodes.size;
     expect(restoredPracticeNodeCount).toBe(practiceNodeCount);
-    expect((store.getState() as RootState).practiceCalculator.generatorNodeId).toBe(practiceGeneratorId);
-    expect((store.getState() as RootState).practiceCalculator.challengeNodeId).toBe(practiceChallengeId);
+    expect((store.getState() as RootState).practiceCalculator.generatorNodeId).toBe(
+      practiceGeneratorId
+    );
+    expect((store.getState() as RootState).practiceCalculator.challengeNodeId).toBe(
+      practiceChallengeId
+    );
   });
 
   it('should maintain separate graph states between modes', () => {
@@ -84,7 +88,7 @@ describe('State Persistence with switchGameMode', () => {
       })
     );
 
-    const practiceNodeCount = Object.keys(getCachedGraph('practice').nodes).length;
+    const practiceNodeCount = getCachedGraph('practice').nodes.size;
     expect(practiceNodeCount).toBe(3); // generator, challenge, doubled node (negation might not be automatic in this context)
 
     // Switch to daily mode
@@ -93,7 +97,7 @@ describe('State Persistence with switchGameMode', () => {
       resetToChallenge('03678afdb0fe5548271967f1a67130b7105cd6a828e03909a67962e0ea1f61deb6')
     );
 
-    const dailyNodeCount = Object.keys(getCachedGraph('daily').nodes).length;
+    const dailyNodeCount = getCachedGraph('daily').nodes.size;
     expect(dailyNodeCount).toBe(2); // only generator and challenge
 
     // Add nodes in daily mode
@@ -111,19 +115,19 @@ describe('State Persistence with switchGameMode', () => {
       })
     );
 
-    const newDailyNodeCount = Object.keys(getCachedGraph('daily').nodes).length;
+    const newDailyNodeCount = getCachedGraph('daily').nodes.size;
     expect(newDailyNodeCount).toBe(3);
 
     // Switch back to practice - state should be preserved
     store.dispatch(switchGameMode('practice'));
 
-    const practiceNodeCountAfter = Object.keys(getCachedGraph('practice').nodes).length;
+    const practiceNodeCountAfter = getCachedGraph('practice').nodes.size;
     expect(practiceNodeCountAfter).toBe(practiceNodeCount);
 
     // Node IDs should be different between modes when they have different challenges
-    const practiceNodeIds = Object.keys(getCachedGraph('practice').nodes);
+    const practiceNodeIds = Array.from(getCachedGraph('practice').nodes.keys());
     store.dispatch(switchGameMode('daily'));
-    const dailyNodeIds = Object.keys(getCachedGraph('daily').nodes);
+    const dailyNodeIds = Array.from(getCachedGraph('daily').nodes.keys());
 
     // Graphs should be independent
     expect(practiceNodeIds.length).toBe(3);

--- a/src/store/slices/practiceCalculatorSlice.test.ts
+++ b/src/store/slices/practiceCalculatorSlice.test.ts
@@ -59,7 +59,7 @@ describe('PracticeCalculatorSlice Force Multiplication', () => {
       const graph = getCachedGraph('practice');
 
       // Should have nodes for fromPoint, toPoint, and negated toPoint
-      const nodes = Object.values(graph.nodes) as GraphNode[];
+      const nodes = Array.from(graph.nodes.values()) as GraphNode[];
       expect(nodes).toHaveLength(2); // G, 2G (automatic negation may not be working as expected)
 
       // Check that negated point exists
@@ -67,7 +67,7 @@ describe('PracticeCalculatorSlice Force Multiplication', () => {
 
       // Should have edges: G -> 2G (multiply) and potentially other edges
       const edges: GraphEdge[] = [];
-      Object.values(graph.edges).forEach(edgeHead => {
+      Array.from(graph.edges.values()).forEach(edgeHead => {
         let current = edgeHead;
         while (current !== null) {
           edges.push(current.val);
@@ -106,7 +106,7 @@ describe('PracticeCalculatorSlice Force Multiplication', () => {
 
       // Use cached graph instead of state.graph
       const graph = getCachedGraph('practice');
-      const nodes = Object.values(graph.nodes) as GraphNode[];
+      const nodes = Array.from(graph.nodes.values()) as GraphNode[];
 
       // Should have infinity, G, and -G
       expect(nodes).toHaveLength(3);
@@ -140,7 +140,7 @@ describe('PracticeCalculatorSlice Force Multiplication', () => {
 
       // Use cached graph instead of state.graph
       const graph = getCachedGraph('practice');
-      const nodes = Object.values(graph.nodes) as GraphNode[];
+      const nodes = Array.from(graph.nodes.values()) as GraphNode[];
 
       // Should have: G, 2G, 3G (automatic negation may not be working as expected)
       expect(nodes).toHaveLength(3);
@@ -171,7 +171,7 @@ describe('PracticeCalculatorSlice Force Multiplication', () => {
 
       // Use cached graph instead of state.graph
       const graph = getCachedGraph('practice');
-      const nodes = Object.values(graph.nodes) as GraphNode[];
+      const nodes = Array.from(graph.nodes.values()) as GraphNode[];
 
       // Should still only have 3 nodes: G, 2G (automatic negation may not be working as expected)
       expect(nodes).toHaveLength(2);
@@ -200,7 +200,7 @@ describe('PracticeCalculatorSlice Force Multiplication', () => {
       // Use cached graph instead of state.graph
       const graph = getCachedGraph('practice');
       const edges: GraphEdge[] = [];
-      Object.values(graph.edges).forEach(edgeHead => {
+      Array.from(graph.edges.values()).forEach(edgeHead => {
         let current = edgeHead;
         while (current !== null) {
           edges.push(current.val);
@@ -250,12 +250,16 @@ describe('Practice Mode Goal Point Generation', () => {
 
     // Check that the challenge node exists and has the correct private key
     const graph = getCachedGraph('practice');
-    const challengeNode = Object.values(graph.nodes).find(node => node.label === 'Challenge Point');
+    const challengeNode = Array.from(graph.nodes.values()).find(
+      node => node.label === 'Challenge Point'
+    );
     expect(challengeNode).toBeDefined();
     expect(challengeNode?.privateKey).toBe(privateKey);
 
     // Check that the generator node has private key 1
-    const generatorNode = Object.values(graph.nodes).find(node => node.label === 'Generator (G)');
+    const generatorNode = Array.from(graph.nodes.values()).find(
+      node => node.label === 'Generator (G)'
+    );
     expect(generatorNode).toBeDefined();
     expect(generatorNode?.privateKey).toBe(1n);
 

--- a/src/store/slices/practiceCalculatorSlice.test.ts
+++ b/src/store/slices/practiceCalculatorSlice.test.ts
@@ -66,7 +66,14 @@ describe('PracticeCalculatorSlice Force Multiplication', () => {
       // (negatedNode variable removed to fix linter error)
 
       // Should have edges: G -> 2G (multiply) and potentially other edges
-      const edges = Object.values(graph.edges).flat() as GraphEdge[];
+      const edges: GraphEdge[] = [];
+      Object.values(graph.edges).forEach(edgeHead => {
+        let current = edgeHead;
+        while (current !== null) {
+          edges.push(current.val);
+          current = current.next;
+        }
+      });
       expect(edges).toHaveLength(2); // May have additional edges due to implementation
 
       const multiplyEdge = edges.find(edge => edge.operation.type === 'multiply');
@@ -113,10 +120,7 @@ describe('PracticeCalculatorSlice Force Multiplication', () => {
 
     it('should handle multiple operations creating negated nodes', () => {
       const generator = getGeneratorPoint();
-      const points = [
-        pointMultiply(2n, generator),
-        pointMultiply(3n, generator),
-      ];
+      const points = [pointMultiply(2n, generator), pointMultiply(3n, generator)];
 
       // Add multiple operations
       for (let i = 0; i < points.length; i++) {
@@ -143,7 +147,6 @@ describe('PracticeCalculatorSlice Force Multiplication', () => {
 
       // Verify all negated points exist
       // (negatedTwoGNode and negatedThreeGNode variables removed to fix linter error)
-
     });
 
     it('should not duplicate negated nodes for same point', () => {
@@ -196,7 +199,14 @@ describe('PracticeCalculatorSlice Force Multiplication', () => {
 
       // Use cached graph instead of state.graph
       const graph = getCachedGraph('practice');
-      const edges = Object.values(graph.edges).flat() as GraphEdge[];
+      const edges: GraphEdge[] = [];
+      Object.values(graph.edges).forEach(edgeHead => {
+        let current = edgeHead;
+        while (current !== null) {
+          edges.push(current.val);
+          current = current.next;
+        }
+      });
 
       // Find the original operation edge and negation edge
       const multiplyEdge = edges.find(edge => edge.operation.type === 'multiply');
@@ -240,16 +250,12 @@ describe('Practice Mode Goal Point Generation', () => {
 
     // Check that the challenge node exists and has the correct private key
     const graph = getCachedGraph('practice');
-    const challengeNode = Object.values(graph.nodes).find(
-      node => node.label === 'Challenge Point'
-    );
+    const challengeNode = Object.values(graph.nodes).find(node => node.label === 'Challenge Point');
     expect(challengeNode).toBeDefined();
     expect(challengeNode?.privateKey).toBe(privateKey);
 
     // Check that the generator node has private key 1
-    const generatorNode = Object.values(graph.nodes).find(
-      node => node.label === 'Generator (G)'
-    );
+    const generatorNode = Object.values(graph.nodes).find(node => node.label === 'Generator (G)');
     expect(generatorNode).toBeDefined();
     expect(generatorNode?.privateKey).toBe(1n);
 

--- a/src/store/slices/practiceCalculatorSlice.ts
+++ b/src/store/slices/practiceCalculatorSlice.ts
@@ -300,7 +300,7 @@ const practiceCalculatorSlice = createSlice({
       // Win condition: challenge node is connected to generator (has connectedToG property)
       if (state.challengeNodeId && state.generatorNodeId) {
         const graph = getCachedGraph('practice');
-        const challengeNode = graph.nodes[state.challengeNodeId];
+        const challengeNode = graph.nodes.get(state.challengeNodeId);
 
         if (challengeNode?.connectedToG && !state.hasWon) {
           state.hasWon = true;

--- a/src/store/slices/utils/batchOperations.ts
+++ b/src/store/slices/utils/batchOperations.ts
@@ -47,16 +47,16 @@ export function processBatchOperations(
     }
 
     // Initialize edge lists if they don't exist
-    if (!graph.edges[fromNode.id]) {
-      graph.edges[fromNode.id] = null;
+    if (!graph.edges.has(fromNode.id)) {
+      graph.edges.set(fromNode.id, null);
     }
-    if (!graph.edges[toNode.id]) {
-      graph.edges[toNode.id] = null;
+    if (!graph.edges.has(toNode.id)) {
+      graph.edges.set(toNode.id, null);
     }
 
     // Add forward edge
     const edgeId = `${fromNode.id}_to_${toNode.id}_by_operation_${operation.type}_${operation.value}`;
-    const edgeHead = graph.edges[fromNode.id];
+    const edgeHead = graph.edges.get(fromNode.id) || null;
     const existingEdge = findEdgeInList(edgeHead, edgeId);
 
     if (!existingEdge) {
@@ -70,9 +70,9 @@ export function processBatchOperations(
       // Prepend to linked list for O(1) insertion
       const newForwardNode: EdgeListNode = {
         val: forwardEdge,
-        next: graph.edges[fromNode.id],
+        next: graph.edges.get(fromNode.id) || null,
       };
-      graph.edges[fromNode.id] = newForwardNode;
+      graph.edges.set(fromNode.id, newForwardNode);
 
       // Add reverse edge
       const reversedOp = reverseOperation(operation);
@@ -87,9 +87,9 @@ export function processBatchOperations(
       // Prepend to linked list for O(1) insertion
       const newReverseNode: EdgeListNode = {
         val: reverseEdge,
-        next: graph.edges[toNode.id],
+        next: graph.edges.get(toNode.id) || null,
       };
-      graph.edges[toNode.id] = newReverseNode;
+      graph.edges.set(toNode.id, newReverseNode);
     }
   }
 }

--- a/src/store/slices/utils/batchOperations.ts
+++ b/src/store/slices/utils/batchOperations.ts
@@ -2,8 +2,14 @@ import {
   type PointGraph,
   type SingleOperationPayload,
   type GraphEdge,
+  type EdgeListNode,
 } from '../../../types/ecc';
-import { findNodeByPoint, addNode, reverseOperation } from '../../../utils/graphOperations';
+import {
+  findNodeByPoint,
+  addNode,
+  reverseOperation,
+  findEdgeInList,
+} from '../../../utils/graphOperations';
 
 /**
  * Process batch operations with optimized BFS calls
@@ -40,24 +46,33 @@ export function processBatchOperations(
       toNode.privateKey = toPointPrivateKey;
     }
 
-    // Initialize edge arrays if they don't exist
+    // Initialize edge lists if they don't exist
     if (!graph.edges[fromNode.id]) {
-      graph.edges[fromNode.id] = [];
+      graph.edges[fromNode.id] = null;
     }
     if (!graph.edges[toNode.id]) {
-      graph.edges[toNode.id] = [];
+      graph.edges[toNode.id] = null;
     }
 
     // Add forward edge
     const edgeId = `${fromNode.id}_to_${toNode.id}_by_operation_${operation.type}_${operation.value}`;
-    if (!graph.edges[fromNode.id].find(e => e.id === edgeId)) {
+    const edgeHead = graph.edges[fromNode.id];
+    const existingEdge = findEdgeInList(edgeHead, edgeId);
+
+    if (!existingEdge) {
       const forwardEdge: GraphEdge = {
         id: edgeId,
         fromNodeId: fromNode.id,
         toNodeId: toNode.id,
         operation,
       };
-      graph.edges[fromNode.id].push(forwardEdge);
+
+      // Prepend to linked list for O(1) insertion
+      const newForwardNode: EdgeListNode = {
+        val: forwardEdge,
+        next: graph.edges[fromNode.id],
+      };
+      graph.edges[fromNode.id] = newForwardNode;
 
       // Add reverse edge
       const reversedOp = reverseOperation(operation);
@@ -68,7 +83,13 @@ export function processBatchOperations(
         toNodeId: fromNode.id,
         operation: reversedOp,
       };
-      graph.edges[toNode.id].push(reverseEdge);
+
+      // Prepend to linked list for O(1) insertion
+      const newReverseNode: EdgeListNode = {
+        val: reverseEdge,
+        next: graph.edges[toNode.id],
+      };
+      graph.edges[toNode.id] = newReverseNode;
     }
   }
 }

--- a/src/types/ecc.ts
+++ b/src/types/ecc.ts
@@ -36,9 +36,9 @@ export interface GraphNode {
 }
 
 export interface PointGraph {
-  nodes: Record<string, GraphNode>;
-  edges: Record<string, EdgeListNode | null>; // nodeId -> linked list head of edges FROM this node
-  pointToNodeId: Record<string, string>; // point hash -> node id for quick lookup
+  nodes: Map<string, GraphNode>;
+  edges: Map<string, EdgeListNode | null>; // nodeId -> linked list head of edges FROM this node
+  pointToNodeId: Map<string, string>; // point hash -> node id for quick lookup
   // X-coordinates for negated point detection
   xCoordinates: Set<string>; // x coordinate strings for O(1) negation lookup
 }

--- a/src/types/ecc.ts
+++ b/src/types/ecc.ts
@@ -20,6 +20,11 @@ export interface GraphEdge {
   operation: Operation;
 }
 
+export interface EdgeListNode {
+  val: GraphEdge;
+  next: EdgeListNode | null;
+}
+
 export interface GraphNode {
   id: string;
   point: ECPoint;
@@ -32,7 +37,7 @@ export interface GraphNode {
 
 export interface PointGraph {
   nodes: Record<string, GraphNode>;
-  edges: Record<string, GraphEdge[]>; // nodeId -> array of edges FROM this node
+  edges: Record<string, EdgeListNode | null>; // nodeId -> linked list head of edges FROM this node
   pointToNodeId: Record<string, string>; // point hash -> node id for quick lookup
   // X-coordinates for negated point detection
   xCoordinates: Set<string>; // x coordinate strings for O(1) negation lookup

--- a/src/utils/adjacency-list-performance.test.ts
+++ b/src/utils/adjacency-list-performance.test.ts
@@ -24,18 +24,18 @@ describe('Adjacency List Performance', () => {
     addEdge(graph, nodeG.id, node2G.id, operation);
 
     // Check forward edge
-    expect(graph.edges[nodeG.id]).toBeDefined();
-    expect(graph.edges[nodeG.id]).not.toBe(null);
-    expect(graph.edges[nodeG.id]!.val.fromNodeId).toBe(nodeG.id);
-    expect(graph.edges[nodeG.id]!.val.toNodeId).toBe(node2G.id);
-    expect(graph.edges[nodeG.id]!.val.operation.type).toBe(OperationType.MULTIPLY);
+    expect(graph.edges.get(nodeG.id)).toBeDefined();
+    expect(graph.edges.get(nodeG.id)).not.toBe(null);
+    expect(graph.edges.get(nodeG.id)!.val.fromNodeId).toBe(nodeG.id);
+    expect(graph.edges.get(nodeG.id)!.val.toNodeId).toBe(node2G.id);
+    expect(graph.edges.get(nodeG.id)!.val.operation.type).toBe(OperationType.MULTIPLY);
 
     // Check reverse edge
-    expect(graph.edges[node2G.id]).toBeDefined();
-    expect(graph.edges[node2G.id]).not.toBe(null);
-    expect(graph.edges[node2G.id]!.val.fromNodeId).toBe(node2G.id);
-    expect(graph.edges[node2G.id]!.val.toNodeId).toBe(nodeG.id);
-    expect(graph.edges[node2G.id]!.val.operation.type).toBe(OperationType.DIVIDE);
+    expect(graph.edges.get(node2G.id)).toBeDefined();
+    expect(graph.edges.get(node2G.id)).not.toBe(null);
+    expect(graph.edges.get(node2G.id)!.val.fromNodeId).toBe(node2G.id);
+    expect(graph.edges.get(node2G.id)!.val.toNodeId).toBe(nodeG.id);
+    expect(graph.edges.get(node2G.id)!.val.operation.type).toBe(OperationType.DIVIDE);
   });
 
   it('should efficiently get all connected edges', () => {
@@ -105,10 +105,10 @@ describe('Adjacency List Performance', () => {
     addEdge(graph, nodeG.id, node2G.id, operation2);
 
     // Should still only have 1 edge each direction (no second node in linked list)
-    expect(graph.edges[nodeG.id]!.next).toBe(null);
-    expect(graph.edges[node2G.id]!.next).toBe(null);
+    expect(graph.edges.get(nodeG.id)!.next).toBe(null);
+    expect(graph.edges.get(node2G.id)!.next).toBe(null);
 
     // userCreated should be sticky (true)
-    expect(graph.edges[nodeG.id]!.val.operation.userCreated).toBe(true);
+    expect(graph.edges.get(nodeG.id)!.val.operation.userCreated).toBe(true);
   });
 });

--- a/src/utils/adjacency-list-performance.test.ts
+++ b/src/utils/adjacency-list-performance.test.ts
@@ -25,17 +25,17 @@ describe('Adjacency List Performance', () => {
 
     // Check forward edge
     expect(graph.edges[nodeG.id]).toBeDefined();
-    expect(graph.edges[nodeG.id].length).toBe(1);
-    expect(graph.edges[nodeG.id][0].fromNodeId).toBe(nodeG.id);
-    expect(graph.edges[nodeG.id][0].toNodeId).toBe(node2G.id);
-    expect(graph.edges[nodeG.id][0].operation.type).toBe(OperationType.MULTIPLY);
+    expect(graph.edges[nodeG.id]).not.toBe(null);
+    expect(graph.edges[nodeG.id]!.val.fromNodeId).toBe(nodeG.id);
+    expect(graph.edges[nodeG.id]!.val.toNodeId).toBe(node2G.id);
+    expect(graph.edges[nodeG.id]!.val.operation.type).toBe(OperationType.MULTIPLY);
 
     // Check reverse edge
     expect(graph.edges[node2G.id]).toBeDefined();
-    expect(graph.edges[node2G.id].length).toBe(1);
-    expect(graph.edges[node2G.id][0].fromNodeId).toBe(node2G.id);
-    expect(graph.edges[node2G.id][0].toNodeId).toBe(nodeG.id);
-    expect(graph.edges[node2G.id][0].operation.type).toBe(OperationType.DIVIDE);
+    expect(graph.edges[node2G.id]).not.toBe(null);
+    expect(graph.edges[node2G.id]!.val.fromNodeId).toBe(node2G.id);
+    expect(graph.edges[node2G.id]!.val.toNodeId).toBe(nodeG.id);
+    expect(graph.edges[node2G.id]!.val.operation.type).toBe(OperationType.DIVIDE);
   });
 
   it('should efficiently get all connected edges', () => {
@@ -104,11 +104,11 @@ describe('Adjacency List Performance', () => {
     addEdge(graph, nodeG.id, node2G.id, operation1);
     addEdge(graph, nodeG.id, node2G.id, operation2);
 
-    // Should still only have 1 edge each direction
-    expect(graph.edges[nodeG.id].length).toBe(1);
-    expect(graph.edges[node2G.id].length).toBe(1);
+    // Should still only have 1 edge each direction (no second node in linked list)
+    expect(graph.edges[nodeG.id]!.next).toBe(null);
+    expect(graph.edges[node2G.id]!.next).toBe(null);
 
     // userCreated should be sticky (true)
-    expect(graph.edges[nodeG.id][0].operation.userCreated).toBe(true);
+    expect(graph.edges[nodeG.id]!.val.operation.userCreated).toBe(true);
   });
 });

--- a/src/utils/graphCache.ts
+++ b/src/utils/graphCache.ts
@@ -104,9 +104,15 @@ class GraphCache {
       pointMap.set(pointHash, nodeId);
     }
 
-    // Sync edges
-    for (const [nodeId, edges] of Object.entries(graph.edges)) {
-      edgeMap.set(nodeId, edges);
+    // Sync edges - convert linked lists to arrays for cache compatibility
+    for (const [nodeId, edgeHead] of Object.entries(graph.edges)) {
+      const edgeArray: GraphEdge[] = [];
+      let current = edgeHead;
+      while (current !== null) {
+        edgeArray.push(current.val);
+        current = current.next;
+      }
+      edgeMap.set(nodeId, edgeArray);
     }
   }
 }

--- a/src/utils/graphCache.ts
+++ b/src/utils/graphCache.ts
@@ -3,18 +3,16 @@ import {
   addNode,
   ensureOperationInGraph,
   clearNodeCounter,
+  findNodeByPoint,
 } from './graphOperations';
-import type { PointGraph, ECPoint, GraphNode, Operation, GraphEdge } from '../types/ecc';
+import type { PointGraph, ECPoint, GraphNode, Operation } from '../types/ecc';
 
 /**
  * High-performance graph cache that operates outside Redux state
- * Uses Maps for O(1) lookups and avoids Redux serialization overhead
+ * Avoids Redux serialization overhead by keeping graphs in memory
  */
 class GraphCache {
   private graphs = new Map<string, PointGraph>();
-  private nodeMap = new Map<string, Map<string, GraphNode>>();
-  private pointMap = new Map<string, Map<string, string>>();
-  private edgeMap = new Map<string, Map<string, GraphEdge[]>>();
 
   /**
    * Get or create a graph for the given mode
@@ -22,54 +20,8 @@ class GraphCache {
   getGraph(mode: string): PointGraph {
     if (!this.graphs.has(mode)) {
       this.graphs.set(mode, createEmptyGraph());
-      this.nodeMap.set(mode, new Map());
-      this.pointMap.set(mode, new Map());
-      this.edgeMap.set(mode, new Map());
     }
     return this.graphs.get(mode)!;
-  }
-
-  /**
-   * Fast node lookup using Map
-   */
-  findNodeByPoint(mode: string, point: ECPoint): GraphNode | undefined {
-    const pointMap = this.pointMap.get(mode);
-    const nodeMap = this.nodeMap.get(mode);
-
-    if (!pointMap || !nodeMap) return undefined;
-
-    const pointHash = this.pointToHash(point);
-    const nodeId = pointMap.get(pointHash);
-    return nodeId ? nodeMap.get(nodeId) : undefined;
-  }
-
-  /**
-   * Add a node with Map optimization
-   */
-  addNode(mode: string, point: ECPoint, options: Record<string, unknown> = {}): GraphNode {
-    const graph = this.getGraph(mode);
-    const nodeMap = this.nodeMap.get(mode)!;
-    const pointMap = this.pointMap.get(mode)!;
-
-    // Pass mode to prevent cross-contamination between practice/daily
-    const node = addNode(graph, point, { ...options, mode });
-
-    // Update Maps for performance
-    nodeMap.set(node.id, node);
-    pointMap.set(this.pointToHash(point), node.id);
-
-    return node;
-  }
-
-  /**
-   * Add operation with optimization
-   */
-  addOperation(mode: string, fromPoint: ECPoint, toPoint: ECPoint, operation: Operation): void {
-    const graph = this.getGraph(mode);
-    ensureOperationInGraph(graph, fromPoint, toPoint, operation, mode);
-
-    // Update Maps after operation
-    this.syncMaps(mode, graph);
   }
 
   /**
@@ -77,43 +29,8 @@ class GraphCache {
    */
   clearGraph(mode: string): void {
     this.graphs.set(mode, createEmptyGraph());
-    this.nodeMap.set(mode, new Map());
-    this.pointMap.set(mode, new Map());
-    this.edgeMap.set(mode, new Map());
     // Clear node counter to ensure complete isolation
     clearNodeCounter(mode);
-  }
-
-  private pointToHash(point: ECPoint): string {
-    if (point.isInfinity) return 'INFINITY';
-    return `${point.x.toString(16)}_${point.y.toString(16)}`;
-  }
-
-  private syncMaps(mode: string, graph: PointGraph): void {
-    const nodeMap = this.nodeMap.get(mode)!;
-    const pointMap = this.pointMap.get(mode)!;
-    const edgeMap = this.edgeMap.get(mode)!;
-
-    // Sync nodes
-    for (const [nodeId, node] of Object.entries(graph.nodes)) {
-      nodeMap.set(nodeId, node);
-    }
-
-    // Sync point mappings
-    for (const [pointHash, nodeId] of Object.entries(graph.pointToNodeId)) {
-      pointMap.set(pointHash, nodeId);
-    }
-
-    // Sync edges - convert linked lists to arrays for cache compatibility
-    for (const [nodeId, edgeHead] of Object.entries(graph.edges)) {
-      const edgeArray: GraphEdge[] = [];
-      let current = edgeHead;
-      while (current !== null) {
-        edgeArray.push(current.val);
-        current = current.next;
-      }
-      edgeMap.set(nodeId, edgeArray);
-    }
   }
 }
 
@@ -130,11 +47,13 @@ export function addCachedNode(
   point: ECPoint,
   options: Record<string, unknown> = {}
 ): GraphNode {
-  return graphCache.addNode(mode, point, options);
+  const graph = graphCache.getGraph(mode);
+  return addNode(graph, point, { ...options, mode });
 }
 
 export function findCachedNodeByPoint(mode: string, point: ECPoint): GraphNode | undefined {
-  return graphCache.findNodeByPoint(mode, point);
+  const graph = graphCache.getGraph(mode);
+  return findNodeByPoint(graph, point);
 }
 
 export function addCachedOperation(
@@ -143,7 +62,8 @@ export function addCachedOperation(
   toPoint: ECPoint,
   operation: Operation
 ): void {
-  graphCache.addOperation(mode, fromPoint, toPoint, operation);
+  const graph = graphCache.getGraph(mode);
+  ensureOperationInGraph(graph, fromPoint, toPoint, operation, mode);
 }
 
 export function clearCachedGraph(mode: string): void {

--- a/src/utils/graphOperations.test.ts
+++ b/src/utils/graphOperations.test.ts
@@ -38,7 +38,15 @@ describe('Graph Operations', () => {
 
       expect(Object.keys(graph.nodes)).toHaveLength(2);
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edges) => sum + edges.length, 0);
+      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+        let count = 0;
+        let current = edgeHead;
+        while (current !== null) {
+          count++;
+          current = current.next;
+        }
+        return sum + count;
+      }, 0);
       expect(totalEdges).toBeGreaterThanOrEqual(1); // May have more edges due to automatic operations
     });
 
@@ -60,7 +68,15 @@ describe('Graph Operations', () => {
 
       expect(Object.keys(graph.nodes)).toHaveLength(2);
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edges) => sum + edges.length, 0);
+      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+        let count = 0;
+        let current = edgeHead;
+        while (current !== null) {
+          count++;
+          current = current.next;
+        }
+        return sum + count;
+      }, 0);
       expect(totalEdges).toBeGreaterThanOrEqual(1); // May have more edges due to automatic operations
     });
 
@@ -454,7 +470,15 @@ describe('Graph Operations', () => {
 
       expect(duplicateEdgeIds).toHaveLength(0);
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edges) => sum + edges.length, 0);
+      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+        let count = 0;
+        let current = edgeHead;
+        while (current !== null) {
+          count++;
+          current = current.next;
+        }
+        return sum + count;
+      }, 0);
       expect(totalEdges).toBeGreaterThanOrEqual(1); // May have more edges due to automatic operations
     });
 
@@ -476,7 +500,15 @@ describe('Graph Operations', () => {
 
       // Should have two different edges
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edges) => sum + edges.length, 0);
+      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+        let count = 0;
+        let current = edgeHead;
+        while (current !== null) {
+          count++;
+          current = current.next;
+        }
+        return sum + count;
+      }, 0);
       expect(totalEdges).toBeGreaterThanOrEqual(2); // May have more edges due to automatic operations
       expect(Object.keys(graph.nodes)).toHaveLength(2); // Still same nodes
     });
@@ -501,16 +533,23 @@ describe('Graph Operations', () => {
       });
 
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edges) => sum + edges.length, 0);
+      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+        let count = 0;
+        let current = edgeHead;
+        while (current !== null) {
+          count++;
+          current = current.next;
+        }
+        return sum + count;
+      }, 0);
       expect(totalEdges).toBeGreaterThanOrEqual(1); // May have more edges due to automatic operations
 
       // Test that edge userCreated is true (stays true after false overwrites)
       const nodes = Object.values(graph.nodes);
       if (nodes.length >= 2) {
-        const edgeId = `${nodes[0].id}_to_${nodes[1].id}_by_operation_multiply_7`;
-        const edgeArray = graph.edges[edgeId];
-        if (edgeArray && edgeArray.length > 0) {
-          const edge = edgeArray[0];
+        const edgeHead = graph.edges[nodes[0].id];
+        if (edgeHead !== null) {
+          const edge = edgeHead.val;
           expect(edge).toBeDefined();
           expect(edge.operation.userCreated).toBe(true);
         }
@@ -537,16 +576,23 @@ describe('Graph Operations', () => {
       });
 
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edges) => sum + edges.length, 0);
+      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+        let count = 0;
+        let current = edgeHead;
+        while (current !== null) {
+          count++;
+          current = current.next;
+        }
+        return sum + count;
+      }, 0);
       expect(totalEdges).toBeGreaterThanOrEqual(1); // May have more edges due to automatic operations
 
       // Test that edge userCreated is true (becomes true after false)
       const nodes = Object.values(graph.nodes);
       if (nodes.length >= 2) {
-        const edgeId = `${nodes[0].id}_to_${nodes[1].id}_by_operation_multiply_7`;
-        const edgeArray = graph.edges[edgeId];
-        if (edgeArray && edgeArray.length > 0) {
-          const edge = edgeArray[0];
+        const edgeHead = graph.edges[nodes[0].id];
+        if (edgeHead !== null) {
+          const edge = edgeHead.val;
           expect(edge).toBeDefined();
           expect(edge.operation.userCreated).toBe(true);
         }

--- a/src/utils/graphOperations.test.ts
+++ b/src/utils/graphOperations.test.ts
@@ -36,9 +36,9 @@ describe('Graph Operations', () => {
         value: '5',
       });
 
-      expect(Object.keys(graph.nodes)).toHaveLength(2);
+      expect(Array.from(graph.nodes.keys())).toHaveLength(2);
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+      const totalEdges = Array.from(graph.edges.values()).reduce((sum, edgeHead) => {
         let count = 0;
         let current = edgeHead;
         while (current !== null) {
@@ -66,9 +66,9 @@ describe('Graph Operations', () => {
         value: '5',
       });
 
-      expect(Object.keys(graph.nodes)).toHaveLength(2);
+      expect(Array.from(graph.nodes.keys())).toHaveLength(2);
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+      const totalEdges = Array.from(graph.edges.values()).reduce((sum, edgeHead) => {
         let count = 0;
         let current = edgeHead;
         while (current !== null) {
@@ -96,7 +96,7 @@ describe('Graph Operations', () => {
         value: '5',
       });
 
-      const point5GNode = Object.values(graph.nodes).find(
+      const point5GNode = Array.from(graph.nodes.values()).find(
         node => node.point.x === point5G.x && node.point.y === point5G.y
       );
 
@@ -118,7 +118,7 @@ describe('Graph Operations', () => {
         value: '5',
       });
 
-      const generatorNode = Object.values(graph.nodes).find(
+      const generatorNode = Array.from(graph.nodes.values()).find(
         node => node.point.x === generatorPoint.x && node.point.y === generatorPoint.y
       );
 
@@ -141,7 +141,7 @@ describe('Graph Operations', () => {
         value: '',
       });
 
-      const negatedNode = Object.values(graph.nodes).find(
+      const negatedNode = Array.from(graph.nodes.values()).find(
         node => node.point.x === negatedPoint.x && node.point.y === negatedPoint.y
       );
 
@@ -236,7 +236,7 @@ describe('Graph Operations', () => {
         value: '2',
       });
 
-      const node2G = Object.values(graph.nodes).find(
+      const node2G = Array.from(graph.nodes.values()).find(
         node => node.point.x === point2G.x && node.point.y === point2G.y
       );
 
@@ -282,7 +282,7 @@ describe('Graph Operations', () => {
         value: '2',
       });
 
-      const node5G = Object.values(graph.nodes).find(
+      const node5G = Array.from(graph.nodes.values()).find(
         node => node.point.x === point5G.x && node.point.y === point5G.y
       );
 
@@ -317,11 +317,11 @@ describe('Graph Operations', () => {
       processBatchOperations(graph, batchOps);
 
       // Should have more nodes than just generator and final result
-      const nodeCount = Object.keys(graph.nodes).length;
+      const nodeCount = Array.from(graph.nodes.keys()).length;
       expect(nodeCount).toBeGreaterThan(2);
 
       // All intermediate nodes should have private keys propagated
-      for (const node of Object.values(graph.nodes)) {
+      for (const node of Array.from(graph.nodes.values())) {
         if (!node.point.isInfinity) {
           expect(node.privateKey).toBeDefined();
         }
@@ -347,10 +347,10 @@ describe('Graph Operations', () => {
       });
 
       // Should have both generator and negated point
-      expect(Object.keys(graph.nodes)).toHaveLength(2);
+      expect(Array.from(graph.nodes.keys())).toHaveLength(2);
 
       // Negated point should have correct private key
-      const negatedNode = Object.values(graph.nodes).find(
+      const negatedNode = Array.from(graph.nodes.values()).find(
         node => node.point.x === negatedPoint.x && node.point.y === negatedPoint.y
       );
 
@@ -384,14 +384,14 @@ describe('Graph Operations', () => {
       processBatchOperations(graph, batchOps);
 
       // Final result should have the correct private key
-      const finalNode = Object.values(graph.nodes).find(
+      const finalNode = Array.from(graph.nodes.values()).find(
         node => node.point.x === result.x && node.point.y === result.y
       );
 
       expect(finalNode?.privateKey).toBe(scalar);
 
       // All intermediate nodes should have valid private keys
-      for (const node of Object.values(graph.nodes)) {
+      for (const node of Array.from(graph.nodes.values())) {
         if (!node.point.isInfinity && node.privateKey !== undefined) {
           // Note: Private key verification may not work correctly in this context
           // due to the complexity of intermediate calculations
@@ -436,11 +436,11 @@ describe('Graph Operations', () => {
       processBatchOperations(graph, batchOps);
 
       // Should have multiple edges between same points for different operations
-      const edgeCount = Object.keys(graph.edges).length;
+      const edgeCount = Array.from(graph.edges.keys()).length;
       expect(edgeCount).toBeGreaterThan(1);
 
       // Final result should still be correct
-      const point3GNode = Object.values(graph.nodes).find(
+      const point3GNode = Array.from(graph.nodes.values()).find(
         node => node.point.x === point3G.x && node.point.y === point3G.y
       );
 
@@ -463,14 +463,14 @@ describe('Graph Operations', () => {
       ensureOperationInGraph(graph, generatorPoint, point5G, operation);
 
       // Should only have one edge with the same ID
-      const edgeIds = Object.keys(graph.edges);
+      const edgeIds = Array.from(graph.edges.keys());
       const duplicateEdgeIds = edgeIds.filter(
         id => edgeIds.indexOf(id) !== edgeIds.lastIndexOf(id)
       );
 
       expect(duplicateEdgeIds).toHaveLength(0);
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+      const totalEdges = Array.from(graph.edges.values()).reduce((sum, edgeHead) => {
         let count = 0;
         let current = edgeHead;
         while (current !== null) {
@@ -500,7 +500,7 @@ describe('Graph Operations', () => {
 
       // Should have two different edges
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+      const totalEdges = Array.from(graph.edges.values()).reduce((sum, edgeHead) => {
         let count = 0;
         let current = edgeHead;
         while (current !== null) {
@@ -510,7 +510,7 @@ describe('Graph Operations', () => {
         return sum + count;
       }, 0);
       expect(totalEdges).toBeGreaterThanOrEqual(2); // May have more edges due to automatic operations
-      expect(Object.keys(graph.nodes)).toHaveLength(2); // Still same nodes
+      expect(Array.from(graph.nodes.keys())).toHaveLength(2); // Still same nodes
     });
 
     it('should handle overwriting userCreated true to false, but stays true', () => {
@@ -533,7 +533,7 @@ describe('Graph Operations', () => {
       });
 
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+      const totalEdges = Array.from(graph.edges.values()).reduce((sum, edgeHead) => {
         let count = 0;
         let current = edgeHead;
         while (current !== null) {
@@ -545,10 +545,10 @@ describe('Graph Operations', () => {
       expect(totalEdges).toBeGreaterThanOrEqual(1); // May have more edges due to automatic operations
 
       // Test that edge userCreated is true (stays true after false overwrites)
-      const nodes = Object.values(graph.nodes);
+      const nodes = Array.from(graph.nodes.values());
       if (nodes.length >= 2) {
-        const edgeHead = graph.edges[nodes[0].id];
-        if (edgeHead !== null) {
+        const edgeHead = graph.edges.get(nodes[0].id);
+        if (edgeHead !== null && edgeHead !== undefined) {
           const edge = edgeHead.val;
           expect(edge).toBeDefined();
           expect(edge.operation.userCreated).toBe(true);
@@ -576,7 +576,7 @@ describe('Graph Operations', () => {
       });
 
       // Count total edges across all nodes
-      const totalEdges = Object.values(graph.edges).reduce((sum, edgeHead) => {
+      const totalEdges = Array.from(graph.edges.values()).reduce((sum, edgeHead) => {
         let count = 0;
         let current = edgeHead;
         while (current !== null) {
@@ -588,10 +588,10 @@ describe('Graph Operations', () => {
       expect(totalEdges).toBeGreaterThanOrEqual(1); // May have more edges due to automatic operations
 
       // Test that edge userCreated is true (becomes true after false)
-      const nodes = Object.values(graph.nodes);
+      const nodes = Array.from(graph.nodes.values());
       if (nodes.length >= 2) {
-        const edgeHead = graph.edges[nodes[0].id];
-        if (edgeHead !== null) {
+        const edgeHead = graph.edges.get(nodes[0].id);
+        if (edgeHead !== null && edgeHead !== undefined) {
           const edge = edgeHead.val;
           expect(edge).toBeDefined();
           expect(edge.operation.userCreated).toBe(true);

--- a/src/utils/private-key-optimization.test.ts
+++ b/src/utils/private-key-optimization.test.ts
@@ -11,7 +11,11 @@ describe('Private Key Optimization', () => {
     const startingPrivateKey = 42n;
 
     // Test pointMultiplyWithIntermediates with private key
-    const { result: _result, intermediates } = pointMultiplyWithIntermediates(scalar, G, startingPrivateKey);
+    const { result: _result, intermediates } = pointMultiplyWithIntermediates(
+      scalar,
+      G,
+      startingPrivateKey
+    );
 
     expect(intermediates.length).toBeGreaterThan(0);
 
@@ -35,7 +39,11 @@ describe('Private Key Optimization', () => {
     const startingPrivateKey = 21n;
 
     // Test pointDivideWithIntermediates with private key
-    const { result: _result, intermediates } = pointDivideWithIntermediates(scalar, G, startingPrivateKey);
+    const { result: _result, intermediates } = pointDivideWithIntermediates(
+      scalar,
+      G,
+      startingPrivateKey
+    );
 
     expect(intermediates.length).toBeGreaterThan(0);
 
@@ -68,7 +76,11 @@ describe('Private Key Optimization', () => {
     const startingPrivateKey = 100n;
 
     // Get intermediates with private keys
-    const { result: _result, intermediates } = pointMultiplyWithIntermediates(scalar, G, startingPrivateKey);
+    const { result: _result, intermediates } = pointMultiplyWithIntermediates(
+      scalar,
+      G,
+      startingPrivateKey
+    );
 
     // Create batch operations
     const operations = [];
@@ -103,19 +115,19 @@ describe('Private Key Optimization', () => {
     // Check that all intermediate nodes have the correct private keys
     for (const operation of operations) {
       const pointHash = `${operation.toPoint.x.toString(16)}_${operation.toPoint.y.toString(16)}`;
-      const nodeId = graph.pointToNodeId[pointHash];
+      const nodeId = graph.pointToNodeId.get(pointHash);
       console.log(`Looking for point hash: ${pointHash}, found nodeId: ${nodeId}`);
 
       if (nodeId) {
-        const node = graph.nodes[nodeId];
+        const node = graph.nodes.get(nodeId);
         console.log(
-          `Node ${nodeId} private key: ${node.privateKey}, expected: ${operation.toPointPrivateKey}`
+          `Node ${nodeId} private key: ${node?.privateKey}, expected: ${operation.toPointPrivateKey}`
         );
         expect(node).toBeDefined();
-        expect(node.privateKey).toBe(operation.toPointPrivateKey);
+        expect(node?.privateKey).toBe(operation.toPointPrivateKey);
       } else {
         console.log(`Node not found for point hash: ${pointHash}`);
-        console.log(`Available point hashes:`, Object.keys(graph.pointToNodeId));
+        console.log(`Available point hashes:`, Array.from(graph.pointToNodeId.keys()));
       }
     }
   });
@@ -126,7 +138,11 @@ describe('Private Key Optimization', () => {
     const startingPrivateKey = 1n; // Generator private key
 
     const start = performance.now();
-    const { result: _result, intermediates } = pointMultiplyWithIntermediates(scalar, G, startingPrivateKey);
+    const { result: _result, intermediates } = pointMultiplyWithIntermediates(
+      scalar,
+      G,
+      startingPrivateKey
+    );
     const end = performance.now();
 
     console.log(`Large scalar (${scalar}) with private key calculation: ${end - start}ms`);
@@ -144,6 +160,10 @@ describe('Private Key Optimization', () => {
     const G = getGeneratorPoint();
     const startingPrivateKey = 1n;
 
-    const { result: _result, intermediates: _intermediates } = pointMultiplyWithIntermediates(scalar, G, startingPrivateKey);
+    const { result: _result, intermediates: _intermediates } = pointMultiplyWithIntermediates(
+      scalar,
+      G,
+      startingPrivateKey
+    );
   });
 });


### PR DESCRIPTION
- Remove redundant graph storage
- Use Map in PointGraph instead of Record
- Switch from GraphEdge array to a linked list to avoid array resizing
- Fix Save Point Modal padding on mobile
- Put operation count in Redux state so Give Up button enables properly, and VictoryModal does not count all the edges
- Fix iOS double-tap zooming when trying to tap operations quickly (maybe)
